### PR TITLE
Use kevent queue for waiting for file unlocking

### DIFF
--- a/llvm/include/llvm/Support/LockFileManager.h
+++ b/llvm/include/llvm/Support/LockFileManager.h
@@ -64,7 +64,10 @@ private:
   static Optional<std::pair<std::string, int> >
   readLockFile(StringRef LockFileName);
 
+  bool waitForUnlockUsingSystemEvents(WaitForUnlockResult *);
+
   static bool processStillExecuting(StringRef Hostname, int PID);
+  static bool shouldListenForProcessState(StringRef HostID);
 
 public:
 


### PR DESCRIPTION
# What
LockFileManager now using File system events in order to check whether the file was deleted
Additional timing between operations added to prevent potential race condition case, when file was deleted right before event queue was set up
In case if the process that owns lock is running on the same host, new implementation will wait for the process to end or until file lock will be remove for 90 seconds (timeout)

# Why
Exponential waiting can dramatically decrease compilation performance. For example, if module A is dependent on Module B, and Module B is performing long compilation, The compilation of module A wiill be delayed on additional deltaT time, which is about the same time as the last waiting interval .